### PR TITLE
Allow passing `repository_credentials` for DockerHub access tokens

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -114,6 +114,11 @@ module "container_definition" {
   port_mappings = var.app_port_mapping
   mount_points  = var.ecs_mount_points
 
+  repository_credentials = (var.repository_credentials_name != null
+    ? { credentialsParameter = data.aws_secretsmanager_secret.creds[0].arn }
+    : null
+  )
+
   log_configuration = (var.enable_datadog_log_forwarder ? {
     logDriver = "awsfirelens"
     options = {

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,12 @@ variable "secret_path" {
   default     = ""
 }
 
+variable "repository_credentials_name" {
+  description = "The SecretsManager Secret Name of the repository credentials to use"
+  type        = string
+  default     = null
+}
+
 variable "app_fqdn" {
   description = "FQDN of app to use. Set this only to override Route53 and ALB's DNS name."
   type        = string


### PR DESCRIPTION
This adds the variable `repository_credentials` which expects a SecretsManager secret name and passes it on to the underlying task definition.

Inputs for the underlying module: https://registry.terraform.io/modules/cloudposse/ecs-container-definition/aws/0.58.1?tab=inputs